### PR TITLE
Hide the links in print css and breadcrumb

### DIFF
--- a/layout/default/micka_print.css
+++ b/layout/default/micka_print.css
@@ -5,3 +5,7 @@
 
 div.print {display: block}
 div.display {display:none}
+
+.breadcrumb {display:none !important}
+
+a[href]:after { content: none }


### PR DESCRIPTION
Hide the links in the CSS printing template, see https://i.imgur.com/zH8q1U0.png